### PR TITLE
[QW-0001]: Autenticación y acceso en base a roles para la creación de solicitudes de préstamo

### DIFF
--- a/applications/app-service/src/main/resources/application.yaml
+++ b/applications/app-service/src/main/resources/application.yaml
@@ -36,6 +36,8 @@ adapter:
   authrestconsumer:
     timeout: 5000
     url: "http://localhost:8080/api"
+jwt:
+  secret: "superLongSecretKeyChangeMeToAtLeast32Bytes"
 resilience4j:
   circuitbreaker:
     instances:

--- a/build.gradle
+++ b/build.gradle
@@ -7,6 +7,7 @@ buildscript {
 		pitestVersion = '1.19.0-rc.1'
         lombokVersion = '1.18.38'
         mapstructVersion = '1.6.3'
+        jjwtVersion = '0.11.5'
 	}
 }
 

--- a/domain/model/src/main/java/co/com/crediya/model/role/enums/Roles.java
+++ b/domain/model/src/main/java/co/com/crediya/model/role/enums/Roles.java
@@ -1,0 +1,22 @@
+package co.com.crediya.model.role.enums;
+
+import lombok.Getter;
+
+import java.util.UUID;
+
+@Getter
+public enum Roles {
+    ADMIN(UUID.fromString("d4e5f6a7-8901-23bc-def4-5678901234cd"), "Administrador", "Acceso total"),
+    ADVISOR(UUID.fromString("c1a2f3e4-5678-90ab-cdef-1234567890ab"), "Asesor", "Gestiona usuarios"),
+    CLIENT(UUID.fromString("e7f8a9b0-1234-56cd-ef78-9012345678ef"),"Cliente", "Acceso limitado");
+
+    private final UUID id;
+    private final String name;
+    private final String description;
+
+    Roles(UUID id, String name, String description) {
+        this.id = id;
+        this.name = name;
+        this.description = description;
+    }
+}

--- a/domain/model/src/main/java/co/com/crediya/model/user/User.java
+++ b/domain/model/src/main/java/co/com/crediya/model/user/User.java
@@ -1,9 +1,5 @@
 package co.com.crediya.model.user;
-import lombok.Builder;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
+import lombok.*;
 
 import java.math.BigDecimal;
 import java.util.UUID;
@@ -20,4 +16,5 @@ public class User {
     private String email;
     private String identityDocument;
     private BigDecimal baseSalary;
+    private String roleId;
 }

--- a/domain/usecase/src/main/java/co/com/crediya/exception/LoanApplicationOwnerMismatchException.java
+++ b/domain/usecase/src/main/java/co/com/crediya/exception/LoanApplicationOwnerMismatchException.java
@@ -1,0 +1,9 @@
+package co.com.crediya.exception;
+
+import co.com.crediya.model.common.exceptions.DomainException;
+
+public class LoanApplicationOwnerMismatchException extends DomainException {
+    public LoanApplicationOwnerMismatchException() {
+        super("LOAN_APPLICATION_OWNER_MISMATCH", "Solo puedes gestionar tus propias solicitudes de préstamo");
+    }
+}

--- a/domain/usecase/src/main/java/co/com/crediya/usecase/registerloanapplication/RegisterLoanApplicationUseCaseInput.java
+++ b/domain/usecase/src/main/java/co/com/crediya/usecase/registerloanapplication/RegisterLoanApplicationUseCaseInput.java
@@ -1,0 +1,11 @@
+package co.com.crediya.usecase.registerloanapplication;
+
+import co.com.crediya.model.loanapplication.LoanApplication;
+import co.com.crediya.model.user.User;
+
+public record RegisterLoanApplicationUseCaseInput(
+        LoanApplication loanApplication,
+        User user,
+        User authUser
+) {
+}

--- a/domain/usecase/src/test/java/co/com/crediya/usecase/registerloanapplication/RegisterLoanApplicationUseCaseTest.java
+++ b/domain/usecase/src/test/java/co/com/crediya/usecase/registerloanapplication/RegisterLoanApplicationUseCaseTest.java
@@ -7,6 +7,7 @@ import co.com.crediya.model.loanapplication.gateways.LoanApplicationRepository;
 import co.com.crediya.model.loantype.enums.LoanTypes;
 import co.com.crediya.model.loantype.gateways.LoanTypeRepository;
 import co.com.crediya.model.status.enums.Statuses;
+import co.com.crediya.model.user.User;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -53,6 +54,15 @@ class RegisterLoanApplicationUseCaseTest {
 
     @Test
     void shouldRegisterLoanApplicationSuccessfully() {
+        var user = User.builder()
+                .id(UUID.randomUUID())
+                .name("Jenner")
+                .lastName("Durand")
+                .email("jennerjose369@gmail.com")
+                .identityDocument("12345678")
+                .baseSalary(new BigDecimal("5000000"))
+                .build();
+
         when(loanApplicationRepository.save(loanApplication)).thenReturn(Mono.just(loanApplication));
         when(loanTypeRepository.existsByCode(LoanTypes.PERSONAL_LOAN.getCode())).thenReturn(Mono.just(true));
         when(transactionalGateway.execute(any()))
@@ -61,7 +71,11 @@ class RegisterLoanApplicationUseCaseTest {
                     return supplier.get();
                 });
 
-        StepVerifier.create(registerLoanApplicationUseCase.execute(loanApplication))
+        StepVerifier.create(registerLoanApplicationUseCase.execute(new RegisterLoanApplicationUseCaseInput(
+                        loanApplication,
+                        user,
+                        user
+                )))
                 .expectNextMatches(u -> u.getIdentityDocument().equals("12345678"))
                 .verifyComplete();
 
@@ -70,6 +84,15 @@ class RegisterLoanApplicationUseCaseTest {
 
     @Test
     void shouldThrowExceptionWhenLoanTypeNotFound() {
+        var user = User.builder()
+                .id(UUID.randomUUID())
+                .name("Jenner")
+                .lastName("Durand")
+                .email("jennerjose369@gmail.com")
+                .identityDocument("12345678")
+                .baseSalary(new BigDecimal("5000000"))
+                .build();
+
         when(loanTypeRepository.existsByCode(LoanTypes.PERSONAL_LOAN.getCode())).thenReturn(Mono.just(false));
         when(transactionalGateway.execute(any()))
                 .thenAnswer(invocation -> {
@@ -77,7 +100,11 @@ class RegisterLoanApplicationUseCaseTest {
                     return supplier.get();
                 });
 
-        StepVerifier.create(registerLoanApplicationUseCase.execute(loanApplication))
+        StepVerifier.create(registerLoanApplicationUseCase.execute(new RegisterLoanApplicationUseCaseInput(
+                        loanApplication,
+                        user,
+                        user
+                )))
                 .expectErrorMatches(LoanTypeNotFoundException.class::isInstance)
                 .verify();
     }

--- a/infrastructure/driven-adapters/auth-rest-consumer/build.gradle
+++ b/infrastructure/driven-adapters/auth-rest-consumer/build.gradle
@@ -2,6 +2,7 @@ dependencies {
     implementation project(':model')
     implementation 'org.springframework:spring-context'
     implementation 'org.springframework.boot:spring-boot-starter-webflux'
+    implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-aop'
     implementation 'io.github.resilience4j:resilience4j-spring-boot3:2.3.0'
     implementation 'io.github.resilience4j:resilience4j-reactor:2.3.0'

--- a/infrastructure/entry-points/reactive-web/build.gradle
+++ b/infrastructure/entry-points/reactive-web/build.gradle
@@ -2,11 +2,18 @@ dependencies {
     implementation project(':usecase')
     implementation project(':model')
     implementation 'org.springframework.boot:spring-boot-starter-webflux'
+    implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
     implementation 'io.micrometer:micrometer-registry-prometheus'
     implementation 'org.springdoc:springdoc-openapi-starter-webflux-ui:2.4.0'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation "org.mapstruct:mapstruct:$mapstructVersion"
+
+    testImplementation "org.springframework.security:spring-security-test"
+
+    implementation "io.jsonwebtoken:jjwt-api:$jjwtVersion"
+    runtimeOnly "io.jsonwebtoken:jjwt-impl:$jjwtVersion"
+    runtimeOnly "io.jsonwebtoken:jjwt-jackson:$jjwtVersion"
 
     annotationProcessor "org.mapstruct:mapstruct-processor:$mapstructVersion"
 }

--- a/infrastructure/entry-points/reactive-web/src/main/java/co/com/crediya/api/authentication/filter/AuthUserDetails.java
+++ b/infrastructure/entry-points/reactive-web/src/main/java/co/com/crediya/api/authentication/filter/AuthUserDetails.java
@@ -1,0 +1,57 @@
+package co.com.crediya.api.authentication.filter;
+
+import lombok.Getter;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.Collection;
+
+public class AuthUserDetails implements UserDetails {
+    @Getter
+    private final String id;
+    private final String username;
+    private final String password;
+    private final Collection<? extends GrantedAuthority> authorities;
+
+    public AuthUserDetails(
+            String id,
+            String username,
+            String password,
+            Collection<? extends GrantedAuthority> authorities
+    ){
+        this.id = id;
+        this.username = username;
+        this.password = password;
+        this.authorities = authorities;
+    }
+
+    public String getRoleId() {
+        return authorities.stream()
+                .findFirst()
+                .map(GrantedAuthority::getAuthority)
+                .orElse(null);
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return authorities;
+    }
+
+    @Override
+    public String getPassword() { return password; }
+
+    @Override
+    public String getUsername() { return username; }
+
+    @Override
+    public boolean isAccountNonExpired() { return true; }
+
+    @Override
+    public boolean isAccountNonLocked() { return true; }
+
+    @Override
+    public boolean isCredentialsNonExpired() { return true; }
+
+    @Override
+    public boolean isEnabled() { return true; }
+}

--- a/infrastructure/entry-points/reactive-web/src/main/java/co/com/crediya/api/authentication/filter/AuthenticationManager.java
+++ b/infrastructure/entry-points/reactive-web/src/main/java/co/com/crediya/api/authentication/filter/AuthenticationManager.java
@@ -1,0 +1,39 @@
+package co.com.crediya.api.authentication.filter;
+
+import co.com.crediya.api.contract.TokenValidator;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.ReactiveAuthenticationManager;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.stereotype.Component;
+import reactor.core.publisher.Mono;
+
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class AuthenticationManager implements ReactiveAuthenticationManager {
+
+    private final TokenValidator tokenValidator;
+
+    @Override
+    public Mono<Authentication> authenticate(Authentication authentication) {
+        String authToken = authentication.getCredentials().toString();
+
+        return tokenValidator.validateTokenAndGetClaims(authToken)
+                .map(claimsDTO ->
+                        new AuthUserDetails(
+                                claimsDTO.userId(),
+                                claimsDTO.username(),
+                                authToken,
+                                List.of(claimsDTO::roleId)
+                        )
+                ).map(userDetails ->
+                        new UsernamePasswordAuthenticationToken(
+                                userDetails,
+                                userDetails.getPassword(),
+                                userDetails.getAuthorities()
+                        )
+                );
+    }
+}

--- a/infrastructure/entry-points/reactive-web/src/main/java/co/com/crediya/api/authentication/filter/SecurityContextRepository.java
+++ b/infrastructure/entry-points/reactive-web/src/main/java/co/com/crediya/api/authentication/filter/SecurityContextRepository.java
@@ -1,0 +1,37 @@
+package co.com.crediya.api.authentication.filter;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.http.HttpHeaders;
+import org.springframework.security.authentication.ReactiveAuthenticationManager;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextImpl;
+import org.springframework.security.web.server.context.ServerSecurityContextRepository;
+import org.springframework.stereotype.Component;
+import org.springframework.web.server.ServerWebExchange;
+import reactor.core.publisher.Mono;
+
+@Component
+@RequiredArgsConstructor
+public class SecurityContextRepository implements ServerSecurityContextRepository {
+
+    private final ReactiveAuthenticationManager authenticationManager;
+
+    @Override
+    public Mono<Void> save(ServerWebExchange exchange, SecurityContext context) {
+        return Mono.empty();
+    }
+
+    @Override
+    public Mono<SecurityContext> load(ServerWebExchange exchange) {
+        String authHeader = exchange.getRequest().getHeaders().getFirst(HttpHeaders.AUTHORIZATION);
+
+        if (authHeader != null && authHeader.startsWith("Bearer ")) {
+            String authToken = authHeader.substring(7);
+            var auth = new UsernamePasswordAuthenticationToken(authToken, authToken);
+
+            return authenticationManager.authenticate(auth).map(SecurityContextImpl::new);
+        }
+        return Mono.empty();
+    }
+}

--- a/infrastructure/entry-points/reactive-web/src/main/java/co/com/crediya/api/config/SecurityConfig.java
+++ b/infrastructure/entry-points/reactive-web/src/main/java/co/com/crediya/api/config/SecurityConfig.java
@@ -1,0 +1,39 @@
+package co.com.crediya.api.config;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.authentication.ReactiveAuthenticationManager;
+import org.springframework.security.config.web.server.ServerHttpSecurity;
+import org.springframework.security.web.server.SecurityWebFilterChain;
+import org.springframework.security.web.server.context.ServerSecurityContextRepository;
+
+@Configuration
+@RequiredArgsConstructor
+public class SecurityConfig {
+
+    private final ReactiveAuthenticationManager authenticationManager;
+    private final ServerSecurityContextRepository securityContextRepository;
+
+    private static final String [] PUBLIC_URLS = {
+            "/api/v1/login",
+            "/v3/api-docs/**",
+            "/swagger-ui.html",
+            "/swagger-ui/**",
+            "/webjars/**"
+    };
+
+    @Bean
+    public SecurityWebFilterChain securityWebFilterChain(ServerHttpSecurity http) {
+        return http
+                .csrf(ServerHttpSecurity.CsrfSpec::disable)
+                .authenticationManager(authenticationManager)
+                .securityContextRepository(securityContextRepository)
+                .authorizeExchange(exchanges -> exchanges
+                        .pathMatchers(PUBLIC_URLS)
+                        .permitAll()
+                        .anyExchange().authenticated()
+                )
+                .build();
+    }
+}

--- a/infrastructure/entry-points/reactive-web/src/main/java/co/com/crediya/api/contract/DTOValidator.java
+++ b/infrastructure/entry-points/reactive-web/src/main/java/co/com/crediya/api/contract/DTOValidator.java
@@ -1,4 +1,4 @@
-package co.com.crediya.api.presentation.contract;
+package co.com.crediya.api.contract;
 
 import reactor.core.publisher.Mono;
 

--- a/infrastructure/entry-points/reactive-web/src/main/java/co/com/crediya/api/contract/RoleValidator.java
+++ b/infrastructure/entry-points/reactive-web/src/main/java/co/com/crediya/api/contract/RoleValidator.java
@@ -1,0 +1,8 @@
+package co.com.crediya.api.contract;
+
+import co.com.crediya.model.role.enums.Roles;
+import reactor.core.publisher.Mono;
+
+public interface RoleValidator {
+    Mono<Void> validateRole(Roles... roles);
+}

--- a/infrastructure/entry-points/reactive-web/src/main/java/co/com/crediya/api/contract/RouteHandler.java
+++ b/infrastructure/entry-points/reactive-web/src/main/java/co/com/crediya/api/contract/RouteHandler.java
@@ -1,4 +1,4 @@
-package co.com.crediya.api.presentation.contract;
+package co.com.crediya.api.contract;
 
 import org.springframework.web.reactive.function.server.ServerRequest;
 import org.springframework.web.reactive.function.server.ServerResponse;

--- a/infrastructure/entry-points/reactive-web/src/main/java/co/com/crediya/api/contract/TokenValidator.java
+++ b/infrastructure/entry-points/reactive-web/src/main/java/co/com/crediya/api/contract/TokenValidator.java
@@ -1,0 +1,8 @@
+package co.com.crediya.api.contract;
+
+import co.com.crediya.api.dto.common.ClaimsDTO;
+import reactor.core.publisher.Mono;
+
+public interface TokenValidator {
+    Mono<ClaimsDTO> validateTokenAndGetClaims(String token);
+}

--- a/infrastructure/entry-points/reactive-web/src/main/java/co/com/crediya/api/contract/UUIDValidator.java
+++ b/infrastructure/entry-points/reactive-web/src/main/java/co/com/crediya/api/contract/UUIDValidator.java
@@ -1,4 +1,4 @@
-package co.com.crediya.api.presentation.contract;
+package co.com.crediya.api.contract;
 
 import reactor.core.publisher.Mono;
 

--- a/infrastructure/entry-points/reactive-web/src/main/java/co/com/crediya/api/dto/common/ClaimsDTO.java
+++ b/infrastructure/entry-points/reactive-web/src/main/java/co/com/crediya/api/dto/common/ClaimsDTO.java
@@ -1,0 +1,7 @@
+package co.com.crediya.api.dto.common;
+
+public record ClaimsDTO(
+        String userId,
+        String username,
+        String roleId
+) {}

--- a/infrastructure/entry-points/reactive-web/src/main/java/co/com/crediya/api/exception/GlobalErrorAttributes.java
+++ b/infrastructure/entry-points/reactive-web/src/main/java/co/com/crediya/api/exception/GlobalErrorAttributes.java
@@ -1,6 +1,7 @@
 package co.com.crediya.api.exception;
 
 import co.com.crediya.api.dto.common.ErrorResponseDTO;
+import co.com.crediya.api.validation.exception.ForbiddenException;
 import co.com.crediya.api.validation.exception.ValidationException;
 import co.com.crediya.exception.NotFoundException;
 import co.com.crediya.model.common.exceptions.DomainException;
@@ -46,14 +47,15 @@ public class GlobalErrorAttributes extends DefaultErrorAttributes {
             return HttpStatus.UNPROCESSABLE_ENTITY;
         } else if (error instanceof ValidationException) {
             return HttpStatus.UNPROCESSABLE_ENTITY;
+        } else if (error instanceof ForbiddenException) {
+            return HttpStatus.FORBIDDEN;
         } else {
             return HttpStatus.INTERNAL_SERVER_ERROR;
         }
     }
 
     private String getErrorMessageByException(Throwable error, ServerRequest request) {
-
-        String errorMessage = "Un error inesperado ha ocurrido";
+        var errorMessage = "Un error inesperado ha ocurrido";
 
         if (error instanceof ConstraintViolationException cve) {
             errorMessage = cve.getConstraintViolations()
@@ -89,6 +91,16 @@ public class GlobalErrorAttributes extends DefaultErrorAttributes {
                     request.method().name(),
                     request.path(),
                     ve.getMessage()
+            );
+        } else if (error instanceof ForbiddenException fe) {
+            errorMessage = fe.getMessage();
+
+            log.warn("[{}] {} {} {}: {}",
+                    request.exchange().getRequest().getId(),
+                    request.method().name(),
+                    request.path(),
+                    fe.getClass().getSimpleName(),
+                    fe.getMessage()
             );
         } else {
             log.error("[{}] Excepción no controlada {} {}: {}",

--- a/infrastructure/entry-points/reactive-web/src/main/java/co/com/crediya/api/provider/jwt/JwtProperties.java
+++ b/infrastructure/entry-points/reactive-web/src/main/java/co/com/crediya/api/provider/jwt/JwtProperties.java
@@ -1,0 +1,16 @@
+package co.com.crediya.api.provider.jwt;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+@Setter
+@Getter
+@Configuration
+@ConfigurationProperties(prefix = "jwt")
+public class JwtProperties {
+
+    private String secret;
+
+}

--- a/infrastructure/entry-points/reactive-web/src/main/java/co/com/crediya/api/provider/jwt/JwtTokenValidator.java
+++ b/infrastructure/entry-points/reactive-web/src/main/java/co/com/crediya/api/provider/jwt/JwtTokenValidator.java
@@ -1,0 +1,42 @@
+package co.com.crediya.api.provider.jwt;
+
+import co.com.crediya.api.dto.common.ClaimsDTO;
+import co.com.crediya.api.contract.TokenValidator;
+import io.jsonwebtoken.security.Keys;
+import org.springframework.stereotype.Component;
+import io.jsonwebtoken.Jwts;
+import reactor.core.publisher.Mono;
+
+import java.util.Date;
+
+@Component
+public class JwtTokenValidator implements TokenValidator {
+
+    private final JwtProperties properties;
+
+    public JwtTokenValidator(JwtProperties properties) {
+        this.properties = properties;
+    }
+
+    public Mono<ClaimsDTO> validateTokenAndGetClaims(String token) {
+        try {
+            var claims = Jwts.parserBuilder()
+                    .setSigningKey(Keys.hmacShaKeyFor(properties.getSecret().getBytes()))
+                    .build()
+                    .parseClaimsJws(token)
+                    .getBody();
+
+            if (claims.getExpiration().before(new Date())) {
+                return Mono.empty();
+            }
+
+            return Mono.just(new ClaimsDTO(
+                    claims.get("userId", String.class),
+                    claims.getSubject(),
+                    claims.get("roleId", String.class)
+            ));
+        } catch (Exception e) {
+            return Mono.empty();
+        }
+    }
+}

--- a/infrastructure/entry-points/reactive-web/src/main/java/co/com/crediya/api/validation/DTOValidatorImp.java
+++ b/infrastructure/entry-points/reactive-web/src/main/java/co/com/crediya/api/validation/DTOValidatorImp.java
@@ -1,6 +1,6 @@
 package co.com.crediya.api.validation;
 
-import co.com.crediya.api.presentation.contract.DTOValidator;
+import co.com.crediya.api.contract.DTOValidator;
 import jakarta.validation.ConstraintViolationException;
 import jakarta.validation.Validator;
 import lombok.RequiredArgsConstructor;

--- a/infrastructure/entry-points/reactive-web/src/main/java/co/com/crediya/api/validation/RoleValidatorImp.java
+++ b/infrastructure/entry-points/reactive-web/src/main/java/co/com/crediya/api/validation/RoleValidatorImp.java
@@ -1,0 +1,34 @@
+package co.com.crediya.api.validation;
+
+import co.com.crediya.api.contract.RoleValidator;
+import co.com.crediya.api.validation.exception.ForbiddenException;
+import co.com.crediya.model.role.enums.Roles;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.context.ReactiveSecurityContextHolder;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.stereotype.Component;
+import reactor.core.publisher.Mono;
+
+import java.util.Arrays;
+
+@Component
+@RequiredArgsConstructor
+public class RoleValidatorImp implements RoleValidator {
+
+    @Override
+    public Mono<Void> validateRole(Roles... roles) {
+        return ReactiveSecurityContextHolder.getContext()
+                .map(SecurityContext::getAuthentication)
+                .flatMap(auth -> {
+                    boolean hasRole = Arrays.stream(roles)
+                            .anyMatch(role -> auth.getAuthorities().stream()
+                                    .anyMatch(granted -> granted.getAuthority().equals(role.getId().toString())));
+                    if (!hasRole) {
+
+                        return Mono.error(new ForbiddenException("No tiene el rol necesario para realizar esta acción"));
+                    }
+
+                    return Mono.empty();
+                });
+    }
+}

--- a/infrastructure/entry-points/reactive-web/src/main/java/co/com/crediya/api/validation/UUIDValidatorImp.java
+++ b/infrastructure/entry-points/reactive-web/src/main/java/co/com/crediya/api/validation/UUIDValidatorImp.java
@@ -1,6 +1,6 @@
 package co.com.crediya.api.validation;
 
-import co.com.crediya.api.presentation.contract.UUIDValidator;
+import co.com.crediya.api.contract.UUIDValidator;
 import co.com.crediya.api.validation.exception.InvalidUUIDException;
 import org.springframework.stereotype.Component;
 import reactor.core.publisher.Mono;

--- a/infrastructure/entry-points/reactive-web/src/main/java/co/com/crediya/api/validation/exception/ForbiddenException.java
+++ b/infrastructure/entry-points/reactive-web/src/main/java/co/com/crediya/api/validation/exception/ForbiddenException.java
@@ -1,0 +1,7 @@
+package co.com.crediya.api.validation.exception;
+
+public class ForbiddenException extends RuntimeException {
+    public ForbiddenException(String message) {
+        super(message);
+    }
+}

--- a/infrastructure/entry-points/reactive-web/src/test/java/co/com/crediya/api/v1/LoanApplicationRouterV1Test.java
+++ b/infrastructure/entry-points/reactive-web/src/test/java/co/com/crediya/api/v1/LoanApplicationRouterV1Test.java
@@ -1,21 +1,28 @@
 package co.com.crediya.api.v1;
 
+import co.com.crediya.api.authentication.filter.AuthUserDetails;
+import co.com.crediya.api.contract.DTOValidator;
+import co.com.crediya.api.contract.RoleValidator;
 import co.com.crediya.api.dto.loanapplication.RegisterLoanApplicationDTO;
 import co.com.crediya.api.dto.loanapplication.ShortLoanApplicationDTO;
 import co.com.crediya.api.exception.GlobalErrorAttributes;
 import co.com.crediya.api.exception.GlobalExceptionHandler;
 import co.com.crediya.api.mapper.LoanApplicationDTOMapper;
-import co.com.crediya.api.presentation.contract.DTOValidator;
 import co.com.crediya.api.presentation.loanapplication.v1.LoanApplicationRouterV1;
 import co.com.crediya.api.presentation.loanapplication.v1.handler.RegisterLoanApplicationHandlerV1;
+import co.com.crediya.api.validation.exception.ForbiddenException;
 import co.com.crediya.exception.UserNotFoundException;
 import co.com.crediya.model.loanapplication.LoanApplication;
 import co.com.crediya.model.loantype.enums.LoanTypes;
+import co.com.crediya.model.role.enums.Roles;
 import co.com.crediya.model.status.enums.Statuses;
 import co.com.crediya.model.user.User;
 import co.com.crediya.usecase.getuserbyidentitydocument.GetUserByIdentityDocumentUseCase;
 import co.com.crediya.usecase.registerloanapplication.RegisterLoanApplicationUseCase;
+import co.com.crediya.usecase.registerloanapplication.RegisterLoanApplicationUseCaseInput;
+import jakarta.validation.ConstraintViolationException;
 import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.web.WebProperties;
@@ -23,22 +30,32 @@ import org.springframework.boot.test.autoconfigure.web.reactive.WebFluxTest;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.http.MediaType;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.config.web.server.ServerHttpSecurity;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.web.server.SecurityWebFilterChain;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.reactive.server.WebTestClient;
 import reactor.core.publisher.Mono;
 
-import static org.mockito.Mockito.*;
-
 import java.math.BigDecimal;
+import java.util.HashSet;
+import java.util.List;
 import java.util.UUID;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.reactive.server.SecurityMockServerConfigurers.mockAuthentication;
 
 @ContextConfiguration(classes = {
         GlobalExceptionHandler.class,
         GlobalErrorAttributes.class,
         LoanApplicationRouterV1.class,
         RegisterLoanApplicationHandlerV1.class,
-        LoanApplicationRouterV1Test.TestConfig.class
+        LoanApplicationRouterV1Test.TestConfig.class,
+        LoanApplicationRouterV1Test.TestSecurityConfig.class
 })
 @WebFluxTest
 class LoanApplicationRouterV1Test {
@@ -56,6 +73,9 @@ class LoanApplicationRouterV1Test {
     private DTOValidator dtoValidator;
 
     @MockitoBean
+    private RoleValidator roleValidator;
+
+    @MockitoBean
     private LoanApplicationDTOMapper mapper;
 
     @TestConfiguration
@@ -66,97 +86,71 @@ class LoanApplicationRouterV1Test {
         }
     }
 
+    @TestConfiguration
+    static class TestSecurityConfig {
+        @Bean
+        public SecurityWebFilterChain securityWebFilterChain(ServerHttpSecurity http) {
+            return http
+                    .csrf(ServerHttpSecurity.CsrfSpec::disable)
+                    .authorizeExchange(ex -> ex.anyExchange().permitAll())
+                    .build();
+        }
+    }
+
+    private AuthUserDetails authUser;
+
+    @BeforeEach
+    void setupAuthUser() {
+        authUser = new AuthUserDetails(
+                UUID.randomUUID().toString(),
+                "jenner@crediya.com",
+                "fake-password",
+                List.of(new SimpleGrantedAuthority(Roles.CLIENT.getId().toString()))
+        );
+    }
+
     @Test
     void testRegisterLoanApplicationSuccess() {
         var sampleId = UUID.randomUUID();
+        var dto = new RegisterLoanApplicationDTO(new BigDecimal("2000000"), 12, LoanTypes.PERSONAL_LOAN.getCode(), "12345678");
+        var user = new User(UUID.randomUUID(), "Jenner", "Durand", "jennerjose369@gmail.com", "12345678", new BigDecimal("5000000"), null);
+        var loanApplication = new LoanApplication(sampleId, new BigDecimal("2000000"), 12, "12345678", user.getEmail(), Statuses.PENDING.getCode(), LoanTypes.PERSONAL_LOAN.getCode());
+        var responseDTO = new ShortLoanApplicationDTO(sampleId.toString(), new BigDecimal("2000000"), 12, "12345678");
 
-        var dto = new RegisterLoanApplicationDTO(
-                new BigDecimal("2000000"),
-                12,
-                LoanTypes.PERSONAL_LOAN.getCode(),
-                "12345678"
-        );
+        when(dtoValidator.validate(dto)).thenReturn(Mono.just(dto));
+        when(getUserByIdentityDocumentUseCase.execute(dto.identityDocument())).thenReturn(Mono.just(user));
+        when(mapper.toModelFromRegisterDTO(dto)).thenReturn(loanApplication);
+        when(roleValidator.validateRole(any())).thenReturn(Mono.empty());
+        when(registerLoanApplicationUseCase.execute(any(RegisterLoanApplicationUseCaseInput.class))).thenReturn(Mono.just(loanApplication));
+        when(mapper.toShortDTOFromModel(loanApplication)).thenReturn(responseDTO);
 
-        var loanApplication = new LoanApplication(
-                sampleId,
-                new BigDecimal("2000000"),
-                12,
-                "12345678",
-                "jennerjose369@gmail.com",
-                Statuses.PENDING.getCode(),
-                LoanTypes.PERSONAL_LOAN.getCode()
-        );
-
-        var user = new User(
-                UUID.randomUUID(),
-                "Jenner",
-                "Durand",
-                "jennerjose369@gmail.com",
-                "12345678",
-                new BigDecimal("5000000")
-        );
-
-        var responseDTO = new ShortLoanApplicationDTO(
-                sampleId.toString(),
-                new BigDecimal("2000000"),
-                12,
-                "12345678"
-        );
-
-        when(dtoValidator.validate(dto))
-                .thenReturn(Mono.just(dto));
-        when(getUserByIdentityDocumentUseCase.execute(dto.identityDocument()))
-                .thenReturn(Mono.just(user));
-        when(mapper.toModelFromRegisterDTO(dto))
-                .thenReturn(loanApplication);
-        when(registerLoanApplicationUseCase.execute(loanApplication))
-                .thenReturn(Mono.just(loanApplication));
-        when(mapper.toShortDTOFromModel(loanApplication))
-                .thenReturn(responseDTO);
-
-        webTestClient.post()
+        webTestClient.mutateWith(mockAuthentication(
+                        new UsernamePasswordAuthenticationToken(authUser, authUser.getPassword(), authUser.getAuthorities())
+                ))
+                .post()
                 .uri("/api/v1/solicitud")
                 .contentType(MediaType.APPLICATION_JSON)
                 .bodyValue(dto)
                 .exchange()
                 .expectStatus().isOk()
                 .expectBody(ShortLoanApplicationDTO.class)
-                .value(userResponse -> {
-                    Assertions
-                            .assertThat(userResponse.identityDocument())
-                            .isEqualTo(user.getIdentityDocument());
-                });
+                .value(userResponse -> Assertions.assertThat(userResponse.identityDocument()).isEqualTo(user.getIdentityDocument()));
     }
 
     @Test
     void testRegisterLoanApplicationUserNotFound() {
-        var sampleId = UUID.randomUUID();
+        var dto = new RegisterLoanApplicationDTO(new BigDecimal("2000000"), 12, LoanTypes.PERSONAL_LOAN.getCode(), "99999999");
+        var loanApplication = new LoanApplication(UUID.randomUUID(), new BigDecimal("2000000"), 12, "99999999", "jenner@crediya.com", Statuses.PENDING.getCode(), LoanTypes.PERSONAL_LOAN.getCode());
 
-        var dto = new RegisterLoanApplicationDTO(
-                new BigDecimal("2000000"),
-                12,
-                LoanTypes.PERSONAL_LOAN.getCode(),
-                "99999999"
-        );
+        when(mapper.toModelFromRegisterDTO(dto)).thenReturn(loanApplication);
+        when(dtoValidator.validate(dto)).thenReturn(Mono.just(dto));
+        when(roleValidator.validateRole(any())).thenReturn(Mono.empty());
+        when(getUserByIdentityDocumentUseCase.execute(anyString())).thenReturn(Mono.error(new UserNotFoundException()));
 
-        var loanApplication = new LoanApplication(
-                sampleId,
-                new BigDecimal("2000000"),
-                12,
-                "99999999",
-                "jennerjose369@gmail.com",
-                Statuses.PENDING.getCode(),
-                LoanTypes.PERSONAL_LOAN.getCode()
-        );
-
-        when(dtoValidator.validate(dto))
-                .thenReturn(Mono.just(dto));
-        when(mapper.toModelFromRegisterDTO(dto))
-                .thenReturn(loanApplication);
-        when(getUserByIdentityDocumentUseCase.execute(anyString()))
-                .thenReturn(Mono.error(new UserNotFoundException()));
-
-        webTestClient.post()
+        webTestClient.mutateWith(mockAuthentication(
+                        new UsernamePasswordAuthenticationToken(authUser, authUser.getPassword(), authUser.getAuthorities())
+                ))
+                .post()
                 .uri("/api/v1/solicitud")
                 .contentType(MediaType.APPLICATION_JSON)
                 .bodyValue(dto)
@@ -166,4 +160,44 @@ class LoanApplicationRouterV1Test {
                 .jsonPath("$.status").isEqualTo(404);
     }
 
+    @Test
+    void testRegisterLoanApplicationValidationFail() {
+        var dto = new RegisterLoanApplicationDTO(new BigDecimal("2000000"), 12, LoanTypes.PERSONAL_LOAN.getCode(), "12345678");
+
+        when(dtoValidator.validate(dto))
+                .thenReturn(Mono.error(
+                        new ConstraintViolationException(
+                                "Validation failed",
+                                new HashSet<>()
+                        )
+                ));
+        when(roleValidator.validateRole(any())).thenReturn(Mono.empty());
+
+        webTestClient.mutateWith(mockAuthentication(
+                        new UsernamePasswordAuthenticationToken(authUser, authUser.getPassword(), authUser.getAuthorities())
+                ))
+                .post()
+                .uri("/api/v1/solicitud")
+                .contentType(MediaType.APPLICATION_JSON)
+                .bodyValue(dto)
+                .exchange()
+                .expectStatus().isEqualTo(422);
+    }
+
+    @Test
+    void testRegisterLoanApplicationForbidden() {
+        var dto = new RegisterLoanApplicationDTO(new BigDecimal("2000000"), 12, LoanTypes.PERSONAL_LOAN.getCode(), "12345678");
+
+        when(roleValidator.validateRole(any())).thenReturn(Mono.error(new ForbiddenException("Access denied")));
+
+        webTestClient.mutateWith(mockAuthentication(
+                        new UsernamePasswordAuthenticationToken(authUser, authUser.getPassword(), authUser.getAuthorities())
+                ))
+                .post()
+                .uri("/api/v1/solicitud")
+                .contentType(MediaType.APPLICATION_JSON)
+                .bodyValue(dto)
+                .exchange()
+                .expectStatus().isForbidden();
+    }
 }

--- a/infrastructure/entry-points/reactive-web/src/test/java/co/com/crediya/authentication/filter/AuthenticationManagerTest.java
+++ b/infrastructure/entry-points/reactive-web/src/test/java/co/com/crediya/authentication/filter/AuthenticationManagerTest.java
@@ -1,0 +1,67 @@
+package co.com.crediya.authentication.filter;
+
+import co.com.crediya.api.authentication.filter.AuthenticationManager;
+import co.com.crediya.api.authentication.filter.AuthUserDetails;
+import co.com.crediya.api.contract.TokenValidator;
+import co.com.crediya.api.dto.common.ClaimsDTO;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.*;
+import static org.assertj.core.api.Assertions.assertThat;
+
+class AuthenticationManagerTest {
+
+    private TokenValidator tokenValidator;
+    private AuthenticationManager authManager;
+
+    @BeforeEach
+    void setup() {
+        tokenValidator = mock(TokenValidator.class);
+        authManager = new AuthenticationManager(tokenValidator);
+    }
+
+    @Test
+    void authenticateShouldReturnAuthenticationWhenTokenIsValid() {
+        var claims = new ClaimsDTO("123", "user@example.com", "role-1");
+        when(tokenValidator.validateTokenAndGetClaims(anyString())).thenReturn(Mono.just(claims));
+
+        Authentication auth = new UsernamePasswordAuthenticationToken("token123", "token123");
+
+        Mono<Authentication> result = authManager.authenticate(auth);
+
+        StepVerifier.create(result)
+                .assertNext(authentication -> {
+                    AuthUserDetails userDetails = (AuthUserDetails) authentication.getPrincipal();
+
+                    assertThat(userDetails.getId()).isEqualTo("123");
+                    assertThat(userDetails.getUsername()).isEqualTo("user@example.com");
+                    assertThat(userDetails.getAuthorities())
+                            .hasSize(1)
+                            .extracting("authority")
+                            .containsExactly("role-1");
+                })
+                .verifyComplete();
+
+        verify(tokenValidator, times(1)).validateTokenAndGetClaims("token123");
+    }
+
+    @Test
+    void authenticateShouldErrorWhenTokenIsInvalid() {
+        when(tokenValidator.validateTokenAndGetClaims(anyString()))
+                .thenReturn(Mono.error(new RuntimeException("Token invalid")));
+
+        Authentication auth = new UsernamePasswordAuthenticationToken("badToken", "badToken");
+
+        StepVerifier.create(authManager.authenticate(auth))
+                .expectErrorMessage("Token invalid")
+                .verify();
+
+        verify(tokenValidator, times(1)).validateTokenAndGetClaims("badToken");
+    }
+}

--- a/infrastructure/entry-points/reactive-web/src/test/java/co/com/crediya/authentication/filter/AuthenticationManagerTest.java
+++ b/infrastructure/entry-points/reactive-web/src/test/java/co/com/crediya/authentication/filter/AuthenticationManagerTest.java
@@ -54,13 +54,13 @@ class AuthenticationManagerTest {
     @Test
     void authenticateShouldErrorWhenTokenIsInvalid() {
         when(tokenValidator.validateTokenAndGetClaims(anyString()))
-                .thenReturn(Mono.error(new RuntimeException("Token invalid")));
+                .thenReturn(Mono.empty());
 
         Authentication auth = new UsernamePasswordAuthenticationToken("badToken", "badToken");
 
         StepVerifier.create(authManager.authenticate(auth))
-                .expectErrorMessage("Token invalid")
-                .verify();
+                .expectNextCount(0)
+                .verifyComplete();
 
         verify(tokenValidator, times(1)).validateTokenAndGetClaims("badToken");
     }

--- a/infrastructure/entry-points/reactive-web/src/test/java/co/com/crediya/authentication/filter/SecurityContextRepositoryTest.java
+++ b/infrastructure/entry-points/reactive-web/src/test/java/co/com/crediya/authentication/filter/SecurityContextRepositoryTest.java
@@ -1,0 +1,58 @@
+package co.com.crediya.authentication.filter;
+
+import co.com.crediya.api.authentication.filter.SecurityContextRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.http.HttpHeaders;
+import org.springframework.mock.http.server.reactive.MockServerHttpRequest;
+import org.springframework.mock.web.server.MockServerWebExchange;
+import org.springframework.security.authentication.ReactiveAuthenticationManager;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContext;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+class SecurityContextRepositoryTest {
+
+    private ReactiveAuthenticationManager authenticationManager;
+    private SecurityContextRepository repository;
+
+    @BeforeEach
+    void setUp() {
+        authenticationManager = Mockito.mock(ReactiveAuthenticationManager.class);
+        repository = new SecurityContextRepository(authenticationManager);
+    }
+
+    @Test
+    void shouldReturnSecurityContextWhenAuthorizationHeaderIsPresent() {
+        var token = "valid-token";
+        var auth = new UsernamePasswordAuthenticationToken("principal", "credentials");
+
+        when(authenticationManager.authenticate(Mockito.any()))
+                .thenReturn(Mono.just(auth));
+
+        var request = MockServerHttpRequest.get("/test")
+                .header(HttpHeaders.AUTHORIZATION, "Bearer " + token)
+                .build();
+        var exchange = MockServerWebExchange.from(request);
+
+        StepVerifier.create(repository.load(exchange))
+                .assertNext(context -> {
+                    assertThat(context).isInstanceOf(SecurityContext.class);
+                })
+                .verifyComplete();
+    }
+
+    @Test
+    void shouldReturnEmptyWhenAuthorizationHeaderIsMissing() {
+        var request = MockServerHttpRequest.get("/test").build();
+        var exchange = MockServerWebExchange.from(request);
+
+        StepVerifier.create(repository.load(exchange))
+                .verifyComplete();
+    }
+}

--- a/infrastructure/entry-points/reactive-web/src/test/java/co/com/crediya/exception/GlobalErrorAttributesTest.java
+++ b/infrastructure/entry-points/reactive-web/src/test/java/co/com/crediya/exception/GlobalErrorAttributesTest.java
@@ -1,6 +1,7 @@
 package co.com.crediya.exception;
 
 import co.com.crediya.api.exception.GlobalErrorAttributes;
+import co.com.crediya.api.validation.exception.ForbiddenException;
 import co.com.crediya.api.validation.exception.InvalidUUIDException;
 import co.com.crediya.model.common.exceptions.DomainException;
 import jakarta.validation.ConstraintViolation;
@@ -89,6 +90,17 @@ class GlobalErrorAttributesTest {
 
         assertThat(attrs).containsEntry("status", 500);
     }
+
+    @Test
+    void shouldReturnForbiddenError() {
+        var forbiddenEx = new ForbiddenException("Acceso denegado");
+        var request = buildRequestWithError(forbiddenEx);
+
+        Map<String, Object> attrs = globalErrorAttributes.getErrorAttributes(request, ErrorAttributeOptions.defaults());
+
+        assertThat(attrs).containsEntry("status", 403);
+    }
+
 
     static class TestDomainException extends DomainException {
         public TestDomainException(String message) {

--- a/infrastructure/entry-points/reactive-web/src/test/java/co/com/crediya/provider/jwt/JwtTokenValidatorTest.java
+++ b/infrastructure/entry-points/reactive-web/src/test/java/co/com/crediya/provider/jwt/JwtTokenValidatorTest.java
@@ -1,0 +1,72 @@
+package co.com.crediya.provider.jwt;
+
+import co.com.crediya.api.provider.jwt.JwtProperties;
+import co.com.crediya.api.provider.jwt.JwtTokenValidator;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.security.Keys;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import reactor.test.StepVerifier;
+
+import java.util.Date;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class JwtTokenValidatorTest {
+
+    private JwtTokenValidator validator;
+    private JwtProperties properties;
+
+    @BeforeEach
+    void setup() {
+        properties = new JwtProperties();
+
+        properties.setSecret("my-super-secret-key-that-is-long-enough!");
+        validator = new JwtTokenValidator(properties);
+    }
+
+    @Test
+    void validateTokenSuccess() {
+        String userId = UUID.randomUUID().toString();
+        String roleId = UUID.randomUUID().toString();
+        String subject = "jenner@crediya.com";
+
+        String token = Jwts.builder()
+                .setSubject(subject)
+                .claim("userId", userId)
+                .claim("roleId", roleId)
+                .setExpiration(new Date(System.currentTimeMillis() + 60_000)) // 1 min
+                .signWith(Keys.hmacShaKeyFor(properties.getSecret().getBytes()), SignatureAlgorithm.HS256)
+                .compact();
+
+        StepVerifier.create(validator.validateTokenAndGetClaims(token))
+                .assertNext(claims -> {
+                    assertEquals(userId, claims.userId());
+                    assertEquals(subject, claims.username());
+                    assertEquals(roleId, claims.roleId());
+                })
+                .verifyComplete();
+    }
+
+    @Test
+    void validateTokenExpiredTokenReturnsEmpty() {
+        String token = Jwts.builder()
+                .setSubject("jenner@crediya.com")
+                .setExpiration(new Date(System.currentTimeMillis() - 1000)) // expirado
+                .signWith(Keys.hmacShaKeyFor(properties.getSecret().getBytes()), SignatureAlgorithm.HS256)
+                .compact();
+
+        StepVerifier.create(validator.validateTokenAndGetClaims(token))
+                .verifyComplete();
+    }
+
+    @Test
+    void validateTokenInvalidTokenReturnsEmpty() {
+        String invalidToken = "this.is.not.a.valid.token";
+
+        StepVerifier.create(validator.validateTokenAndGetClaims(invalidToken))
+                .verifyComplete();
+    }
+}

--- a/infrastructure/entry-points/reactive-web/src/test/java/co/com/crediya/validation/RoleValidatorImpTest.java
+++ b/infrastructure/entry-points/reactive-web/src/test/java/co/com/crediya/validation/RoleValidatorImpTest.java
@@ -1,0 +1,60 @@
+package co.com.crediya.validation;
+
+import co.com.crediya.api.authentication.filter.AuthUserDetails;
+import co.com.crediya.api.validation.RoleValidatorImp;
+import co.com.crediya.api.validation.exception.ForbiddenException;
+import co.com.crediya.model.role.enums.Roles;
+import org.junit.jupiter.api.Test;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.ReactiveSecurityContextHolder;
+import org.springframework.security.core.context.SecurityContextImpl;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+import java.util.List;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class RoleValidatorImpTest {
+
+    private final RoleValidatorImp roleValidator = new RoleValidatorImp();
+
+    private AuthUserDetails buildUserWithRole() {
+        return new AuthUserDetails(
+                UUID.randomUUID().toString(),
+                "user@test.com",
+                "password",
+                List.of(() -> Roles.CLIENT.getId().toString()) // GrantedAuthority
+        );
+    }
+
+    @Test
+    void successWhenUserHasRole() {
+        var userDetails = buildUserWithRole();
+        var auth = new UsernamePasswordAuthenticationToken(userDetails, userDetails.getPassword(), userDetails.getAuthorities());
+        var context = new SecurityContextImpl(auth);
+
+        var result = roleValidator.validateRole(Roles.CLIENT)
+                .contextWrite(ReactiveSecurityContextHolder.withSecurityContext(Mono.just(context)));
+
+        StepVerifier.create(result)
+                .verifyComplete();
+    }
+
+    @Test
+    void errorWhenUserDoesNotHaveRole() {
+        var userDetails = buildUserWithRole();
+        var auth = new UsernamePasswordAuthenticationToken(userDetails, userDetails.getPassword(), userDetails.getAuthorities());
+        var context = new SecurityContextImpl(auth);
+
+        var result = roleValidator.validateRole(Roles.ADMIN)
+                .contextWrite(ReactiveSecurityContextHolder.withSecurityContext(Mono.just(context)));
+
+        StepVerifier.create(result)
+                .expectErrorSatisfies(error -> {
+                    assertThat(error).isInstanceOf(ForbiddenException.class);
+                })
+                .verify();
+    }
+}


### PR DESCRIPTION
## Description  
Se agregó soporte de autenticación JWT y control de acceso basado en roles. Particularmente, el registro de solicitudes de préstamo solo esta permitido para clientes y el préstamo es para ellos mismos.

## Included Changes

- Add `JWT` authentication support and configure secrets in `application.yml`.
- Implement security filters to add JWT authentication.
- Pass bearer token authorization header to `auth-rest-consumer`.
- Update User domain model.
- Add Roles enum to validate role.
- Update `RegisterLoanApplicationUseCase` to validate authUser is the same that loan application user.
- Add `LoanApplicationOwnerMismatchException` exception.
- Add role validator for role-based access control.
- Add unit tests for new contracts and validations.

## Endpoints  

- `POST /api/v1/solicitud` => Requiere `CLIENT` como rol y el usuario que hace la solicitud de préstamo debe ser el mismo para el cual va dirigido el préstamo